### PR TITLE
notion: init at 2.0.1

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,6 @@
 { pkgs ? import <nixpkgs> {} }:
 
 rec {
-  # Homegrown software
   alpinocorpus = pkgs.callPackage ./pkgs/alpinocorpus {};
   alpino-tokenize = pkgs.callPackage ./pkgs/alpino-tokenize {};
   citar = pkgs.callPackage ./pkgs/citar {};
@@ -9,6 +8,8 @@ rec {
   dact = pkgs.libsForQt5.callPackage ./pkgs/dact { alpinocorpus = alpinocorpus; };
 
   libtensorflow = pkgs.callPackage ./pkgs/libtensorflow {};
+
+  notion = pkgs.callPackage ./pkgs/notion {};
 
   # Python packages
   pythonPackages = python2Packages;

--- a/pkgs/notion/default.nix
+++ b/pkgs/notion/default.nix
@@ -1,0 +1,59 @@
+{ stdenv
+, fetchurl
+, libicns
+, makeDesktopItem
+, makeWrapper
+, undmg
+, electron_6
+}:
+
+stdenv.mkDerivation rec {
+  pname = "notion";
+  version = "2.0.1";
+
+  src = fetchurl {
+    url = "https://desktop-release.notion-static.com/Notion-${version}.dmg";
+    sha256 = "131xmcz3v078wfgnwa7dpmjmrwfw0clywy0zzj8i05r2w0868wfy";
+  };
+
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    libicns
+    makeWrapper
+    undmg
+  ];
+
+  preInstallPhase = ''
+  '';
+
+  installPhase = let
+    desktopItem = makeDesktopItem {
+      name = pname;
+      desktopName = "Notion";
+      icon = "${pname}.png";
+      categories = "Office;";
+      exec = "notion";
+    };
+  in ''
+    mkdir -p $out/share
+    cp -r Contents/Resources $out/share/notion
+    makeWrapper ${electron_6}/bin/electron $out/bin/notion \
+      --add-flags $out/share/notion/app.asar \
+      --run "cd $out/share/notion"
+
+    icns2png -x Contents/Resources/Notion.icns
+    install -Dm644 Notion_512x512x32.png \
+      $out/share/icons/hicolor/512x512/apps/notion.png
+
+    ${desktopItem.buildCommand}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "All-in-one workspace for notes, tasks, and wikis";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ danieldk ];
+    hydraPlatforms = [];
+  };
+
+}


### PR DESCRIPTION
One of the redeeming qualities of Electron apps is that if there is no
Linux version, you take another version and run it with Electron.

This derivation takes Notion from the macOS app and rewraps it with
the native Electron version.